### PR TITLE
Flip token images and invert rotation in mirrored zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ Cloned tokens behave a little differently from regular tokens. They can't be mov
 
 ![Token cloning example](demo/cloning.gif)
 
+## True Mirror
+The "True Mirror" flag on a cloning region will flip your token images and invert rotation to allow you to add mirrors to scenes.
+
+![Mirror example](demo/mirror.gif)
+
 ### Notes
 
 * Cloning regions can be any size or shape you like, and can be freely moved or rotated. You can use the polygon tool to create complex shapes. The relative sizes and rotations of **Source** and **Target** regions will be taken into account when cloning tokens: clones will be positioned, rotated, and scaled up or down as necessary. It's usually easiest to start with two copies of the same drawing and go from there.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Cloned tokens behave a little differently from regular tokens. They can't be mov
 ![Token cloning example](demo/cloning.gif)
 
 ## True Mirror
-The "True Mirror" flag on a cloning region will flip your token images and invert rotation to allow you to add mirrors to scenes.
+The "True Mirror" flag on a cloning region will flip your token images and invert rotation to allow you to add mirrors to scenes. It only does anything if "Mirror horizontally" or "Mirror vertically" are enabled.
 
 ![Mirror example](demo/mirror.gif)
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -32,6 +32,7 @@
   "MLT.FieldClonedTokenScale": "Skalierungsfaktor für geklonte Figur",
   "MLT.FieldMirrorHorizontally": "Horizontal spiegeln",
   "MLT.FieldMirrorVertically": "Vertikal spiegeln",
+  "MLT.FieldMirrorTrue": "Wahrer spiegel",
   "MLT.SectionMacroTriggers": "Macro Auslöser",
   "MLT.SectionMacroTriggersNotes": "Löse ein Makro aus, wenn eine Figur diese Region betritt, verlässt oder sich innerhalb bewegt. Innerhalb des Makros geben die Variablen <b>scene</b>, <b>region</b>, <b>token</b> und <b>actor</b> die <b>Scene</b>, <b>Drawing</b>, <b>Token</b> und <b>Actor</b> Objekte zurück, die beteiligt sind.",
   "MLT.FieldTriggerOnEnter": "Beim Betreten auslösen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -32,6 +32,7 @@
   "MLT.FieldClonedTokenScale": "Cloned token scaling factor",
   "MLT.FieldMirrorHorizontally": "Mirror horizontally",
   "MLT.FieldMirrorVertically": "Mirror vertically",
+  "MLT.FieldMirrorTrue": "True Mirror",
   "MLT.SectionMacroTriggers": "Macro triggers",
   "MLT.SectionMacroTriggersNotes": "Trigger a macro when a token enters this region, leaves it, or moves within it. Within the macro, the variables <b>scene</b>, <b>region</b>, <b>token</b> and <b>actor</b> give the <b>Scene</b>, <b>Drawing</b>, <b>Token</b> and <b>Actor</b> objects involved.",
   "MLT.FieldTriggerOnEnter": "Trigger on enter",

--- a/lang/es.json
+++ b/lang/es.json
@@ -35,6 +35,7 @@
   "MLT.FieldClonedTokenScale": "Factor de escala de los iconos clonados",
   "MLT.FieldMirrorHorizontally": "Voltear horizontalmente",
   "MLT.FieldMirrorVertically": "Voltear verticalmente",
+  "MLT.FieldMirrorTrue": "Verdadero espejo",
   "MLT.SectionMacroTriggers": "Disparadores de macros",
   "MLT.SectionMacroTriggersNotes": "Ejecuta una macro cuando un icono entra, sale, o se mueve dentro de esta región. Dentro de la macro, las variables <b>scene</b>, <b>region</b>, <b>token</b> y <b>actor</b> hacen referencia a los objetos correspondientes <b>Scene</b>, <b>Drawing</b>, <b>Token</b> y <b>Actor</b>",
   "MLT.FieldTriggerOnEnter": "Disparar al entrar",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -27,6 +27,7 @@
   "MLT.FieldClonedTokenOpacity": "Opacity for cloned tokens",
   "MLT.FieldMirrorHorizontally": "Inverser horizontalement",
   "MLT.FieldMirrorVertically": "Inverser verticalement",
+  "MLT.FieldMirrorTrue": "Vrai miroir",
   "MLT.SectionMacroTriggers": "Déclencheurs de macros",
   "MLT.SectionMacroTriggersNotes": "Déclencher une macro quand un jeton rentre dans cette région, en sort, ou bouge à l'intérieur. Au sein de la macro, les variables <b>scene</b>, <b>region</b> et <b>token</b> renvoient les objets <b>Scène</b>, <b>Dessin</b> et <b>Jeton</b> correspondants.",
   "MLT.FieldTriggerOnEnter": "Déclencher sur l'entrée",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -32,6 +32,7 @@
   "MLT.FieldClonedTokenScale": "複製されたトークンの縮尺係数",
   "MLT.FieldMirrorHorizontally": "横方向に反転",
   "MLT.FieldMirrorVertically": "縦方向に反転",
+  "MLT.FieldMirrorTrue": "真実の鏡",
   "MLT.SectionMacroTriggers": "マクロトリガー",
   "MLT.SectionMacroTriggersNotes": "トークンがこの領域に入ったとき、出たとき、または領域内を移動したときにマクロを起動します。マクロでは、<strong>scene</strong>、<strong>region</strong>、<strong>token</strong>、<strong>actor</strong> が変数として使用できます。それぞれには <strong>Scene</strong>、<strong>Drawing</strong>、<strong>Token</strong>、<strong>Actor</strong> オブジェクトが格納されています。",
   "MLT.FieldTriggerOnEnter": "入場時にトリガーする",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -32,6 +32,7 @@
   "MLT.FieldClonedTokenScale": "복제된 토큰의 크기 조정 인수",
   "MLT.FieldMirrorHorizontally": "수평적 대칭",
   "MLT.FieldMirrorVertically": "수직적 대칭",
+  "MLT.FieldMirrorTrue": "진실의 거울",
   "MLT.SectionMacroTriggers": "매크로 트리거",
   "MLT.SectionMacroTriggersNotes": "토큰이 영역 내에 들어오거나 나가거나, 안에서 움직일 때 매크로를 작동시킨다. 매크로 내에서 <b>scene</b>, <b>region</b>, <b>token</b>, <b>actor</b> 변수는 관련된 <b>씬</b>, <b>그리기 도구</b>, <b>토큰</b>, <b>액터</b> 객체를 제공한다.",
   "MLT.FieldTriggerOnEnter": "들어갈 때 작동",

--- a/multilevel.js
+++ b/multilevel.js
@@ -536,7 +536,6 @@ class MultilevelTokens {
         data.rotation = -data.rotation
       }
     }
-    console.log(data)
     return data;
   }
 

--- a/multilevel.js
+++ b/multilevel.js
@@ -525,6 +525,17 @@ class MultilevelTokens {
     data.flags[MLT.SCOPE][MLT.FLAG_SOURCE_TOKEN] = token._id;
     data.flags[MLT.SCOPE][MLT.FLAG_SOURCE_REGION] = sourceRegion._id;
     data.flags[MLT.SCOPE][MLT.FLAG_TARGET_REGION] = targetRegion._id;
+    if(this._hasRegionFlag(targetRegion, "flipTrue")){
+      if(this._hasRegionFlag(targetRegion, "flipX")){
+        data.texture.scaleX = -token.texture.scaleX
+      }
+      if(this._hasRegionFlag(targetRegion, "flipY")){
+        data.texture.scaleY = -token.texture.scaleY
+      }
+      if(!(this._hasRegionFlag(targetRegion, "flipY") && this._hasRegionFlag(targetRegion, "flipX"))){
+        data.rotation = -data.rotation
+      }
+    }
     return data;
   }
 
@@ -1277,6 +1288,10 @@ class MultilevelTokens {
           <label for="flags.multilevel-tokens.flipY">${game.i18n.localize("MLT.FieldMirrorVertically")}</label>
           <input type="checkbox" name="flags.multilevel-tokens.flipY" data-dtype="Boolean"/>
         </div>
+        <div class="form-group">
+          <label for="flags.multilevel-tokens.flipTrue">${game.i18n.localize("MLT.FieldMirrorTrue")}</label>
+          <input type="checkbox" name="flags.multilevel-tokens.flipTrue" data-dtype="Boolean"/>
+        </div>
       </div>
       <h3 class="form-header">
         <i class="fas fa-magic"/></i> ${game.i18n.localize("MLT.SectionMacroTriggers")}
@@ -1339,6 +1354,7 @@ class MultilevelTokens {
     input("scale").prop("value", flags.scale || 1);
     input("flipX").prop("checked", flags.flipX);
     input("flipY").prop("checked", flags.flipY);
+    input("flipTrue").prop("checked", flags.flipTrue);
     input("macroEnter").prop("checked", flags.macroEnter);
     input("macroLeave").prop("checked", flags.macroLeave);
     input("macroMove").prop("checked", flags.macroMove);
@@ -1380,6 +1396,7 @@ class MultilevelTokens {
       enable("scale", isTarget);
       enable("flipX", isTarget);
       enable("flipY", isTarget);
+      enable("flipTrue", isTarget);
       enable("macroName", isMacro);
       enable("macroArgs", isMacro);
       enable("levelNumber", isLevel);

--- a/multilevel.js
+++ b/multilevel.js
@@ -513,7 +513,7 @@ class MultilevelTokens {
     data.x = targetPosition.x;
     data.y = targetPosition.y;
     data.rotation += targetRegion.rotation - sourceRegion.rotation;
-    data.tint = Color.fromRGB(tintRgb).toString(16);
+    data.texture.tint = Color.fromRGB(tintRgb).toString(16);
     data.alpha = token.alpha * opacity;
     if (!data.flags || !cloneModuleFlags) {
       data.flags = {};
@@ -536,6 +536,7 @@ class MultilevelTokens {
         data.rotation = -data.rotation
       }
     }
+    console.log(data)
     return data;
   }
 

--- a/multilevel.js
+++ b/multilevel.js
@@ -532,7 +532,7 @@ class MultilevelTokens {
       if(this._hasRegionFlag(targetRegion, "flipY")){
         data.texture.scaleY = -token.texture.scaleY
       }
-      if(!(this._hasRegionFlag(targetRegion, "flipY") && this._hasRegionFlag(targetRegion, "flipX"))){
+      if((this._hasRegionFlag(targetRegion, "flipY") != this._hasRegionFlag(targetRegion, "flipX"))){
         data.rotation = -data.rotation
       }
     }


### PR DESCRIPTION
Adds a new checkbox to cloned regions to invert token images and invert rotation. Rotation will invert if X or Y is flipped, but not if both are. Also fixes clone tinting not applying because `tint `is now a property of `texture` rather than of the token itself. Lang files could maybe do with some work because they're a Google Translate special.